### PR TITLE
更新TRR中鉴权验证使用中间件的方式

### DIFF
--- a/application/http/middleware/Auth.php
+++ b/application/http/middleware/Auth.php
@@ -4,6 +4,8 @@
 
 namespace app\http\middleware;
 
+use app\lib\token\Token;
+
 class Auth
 {
     /**
@@ -14,9 +16,7 @@ class Auth
      */
     public function handle($request, \Closure $next)
     {
-        if (request()->controller() != 'Auth'){
-
-        }
+        Token::verification();
 
         return $next($request);
     }


### PR DESCRIPTION
## 新增鉴权注解中间件 Auth 验证

### 具体修改如下

   1. 更改了 `application/http/middleware/Auth.php` 文件下 `handle` 方法

        ```php

        use app\lib\token\Token;
        // 省略代码 
        public function handle($request, \Closure $next)
        {
            Token::verification();
            return $next($request);
        }
        ```  


### 鉴权中间件使用方式

  
  * TRR 类 中间件注册
   > 例如：`application/api/controller/v1/Book.php`
   
           
          ```php
         /**
          * Class Book
          * @doc('图书类')
          * @group('v1/book')
          * @middleware('Auth')
          * @package app\api\controller\v1
          */
         class Book{}
          ```  

* TRR 类方法 中间件注册
>例如：`application/api/controller/v1/Book.php` 中 `create`

    ```php
        /**
         * @doc('创建图书')
         * @route('','get')
         * @validate('CreateGroup.edit')
         * @middleware('Auth')
         * @param('name','图书名称','require|graph|length:1,50')
         * @param('img','图书img','require|graph|length:1,16')
         * @return \think\response\Json
         * @success('')
         * @error('')
         */
        public function create()
        {
            return json([
                'class' => 'application/api/controller/v1/Book.php',
                'action' => 'create'
            ], 200);
        }    
    ```
    
* 至此访问此接口就需要在 `hearder` 头中传入 `Authorization` 类型为 `Bearer` 的 `access_token` 参数实现权限验证